### PR TITLE
Fix number of digits in the speed prompt

### DIFF
--- a/soundcloud-downloader.py
+++ b/soundcloud-downloader.py
@@ -102,9 +102,9 @@ class SoundCloudDownload:
    def report(self, block_no, block_size, file_size):
       self.download_progress += block_size
       if int(self.download_progress / 1024 * 8) > 1000:
-         speed = "{0} Mbps".format(round((self.download_progress / 1024 / 1024 * 8) / (time.time() - self.current_time), 2))
+         speed = "{0:.2f} Mbps".format(round((self.download_progress / 1024 / 1024 * 8) / (time.time() - self.current_time), 2))
       else:
-         speed = "{0} Kbps".format(round((self.download_progress / 1024 * 8) / (time.time() - self.current_time), 2))
+         speed = "{0:.2f} Kbps".format(round((self.download_progress / 1024 * 8) / (time.time() - self.current_time), 2))
       rProgress = round(self.download_progress/1024.00/1024.00, 2)
       rFile = round(file_size/1024.00/1024.00, 2)
       percent = round(100 * float(self.download_progress)/float(file_size))


### PR DESCRIPTION
Constantly changing speed makes the prompt shake.

This is happening because `round(…)` is a number and can span to any number of digits after a decimal point.

``` python
In [1]: round(1.1, 2)
Out[1]: 1.1

In [2]: round(1.11, 2)
Out[2]: 1.11
```
